### PR TITLE
Add Generic Sensor, Voltage and Percentage data formats

### DIFF
--- a/CayenneLPP.cpp
+++ b/CayenneLPP.cpp
@@ -122,7 +122,7 @@ uint8_t CayenneLPP::addGenericValue (uint8_t channel, float value) {
     buffer[cursor++] = channel;
     buffer[cursor++] = LPP_GENERIC_SENSOR;
 
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if defined ARDUINO || BYTE_ORDER == LITTLE_ENDIAN
     buffer[cursor++] = ptr[3];
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[1];
@@ -227,7 +227,7 @@ uint8_t CayenneLPP::addVoltage (uint8_t channel, float voltage) {
     buffer[cursor++] = channel;
     buffer[cursor++] = LPP_VOLTAGE;
 
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if defined ARDUINO || BYTE_ORDER == LITTLE_ENDIAN
     buffer[cursor++] = ptr[3];
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[1];
@@ -253,7 +253,7 @@ uint8_t CayenneLPP::addPercentage (uint8_t channel, float percent) {
     buffer[cursor++] = channel;
     buffer[cursor++] = LPP_PERCENTAGE;
 
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if defined ARDUINO || BYTE_ORDER == LITTLE_ENDIAN
     buffer[cursor++] = ptr[3];
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[1];

--- a/CayenneLPP.cpp
+++ b/CayenneLPP.cpp
@@ -111,6 +111,24 @@ uint8_t CayenneLPP::addLuminosity(uint8_t channel, uint16_t lux)
   return cursor;
 }
 
+uint8_t addGenericValue (uint8_t channel, float value) {
+    if ((cursor + LPP_GENERIC_SENSOR_SIZE) > maxsize)
+    {
+        return 0;
+    }
+    float val = value;
+    uint8_t *ptr = (uint8_t *)&val;
+
+    buffer[cursor++] = channel;
+    buffer[cursor++] = LPP_GENERIC_SENSOR;
+    buffer[cursor++] = ptr[0];
+    buffer[cursor++] = ptr[1];
+    buffer[cursor++] = ptr[2];
+    buffer[cursor++] = ptr[3];
+
+    return cursor;
+}
+
 uint8_t CayenneLPP::addPresence(uint8_t channel, uint8_t value)
 {
   if ((cursor + LPP_PRESENCE_SIZE) > maxsize)

--- a/CayenneLPP.cpp
+++ b/CayenneLPP.cpp
@@ -121,10 +121,18 @@ uint8_t CayenneLPP::addGenericValue (uint8_t channel, float value) {
 
     buffer[cursor++] = channel;
     buffer[cursor++] = LPP_GENERIC_SENSOR;
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+    buffer[cursor++] = ptr[3];
+    buffer[cursor++] = ptr[2];
+    buffer[cursor++] = ptr[1];
+    buffer[cursor++] = ptr[0];
+#elif
     buffer[cursor++] = ptr[0];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[3];
+#endif
 
     return cursor;
 }
@@ -218,10 +226,18 @@ uint8_t CayenneLPP::addVoltage (uint8_t channel, float voltage) {
 
     buffer[cursor++] = channel;
     buffer[cursor++] = LPP_VOLTAGE;
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+    buffer[cursor++] = ptr[3];
+    buffer[cursor++] = ptr[2];
+    buffer[cursor++] = ptr[1];
+    buffer[cursor++] = ptr[0];
+#elif
     buffer[cursor++] = ptr[0];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[3];
+#endif
 
     return cursor;
 }
@@ -236,10 +252,18 @@ uint8_t CayenneLPP::addPercentage (uint8_t channel, float percent) {
 
     buffer[cursor++] = channel;
     buffer[cursor++] = LPP_PERCENTAGE;
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+    buffer[cursor++] = ptr[3];
+    buffer[cursor++] = ptr[2];
+    buffer[cursor++] = ptr[1];
+    buffer[cursor++] = ptr[0];
+#elif
     buffer[cursor++] = ptr[0];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[3];
+#endif
 
     return cursor;
 }

--- a/CayenneLPP.cpp
+++ b/CayenneLPP.cpp
@@ -111,7 +111,7 @@ uint8_t CayenneLPP::addLuminosity(uint8_t channel, uint16_t lux)
   return cursor;
 }
 
-uint8_t addGenericValue (uint8_t channel, float value) {
+uint8_t CayenneLPP::addGenericValue (uint8_t channel, float value) {
     if ((cursor + LPP_GENERIC_SENSOR_SIZE) > maxsize)
     {
         return 0;
@@ -208,7 +208,7 @@ uint8_t CayenneLPP::addBarometricPressure(uint8_t channel, float hpa)
   return cursor;
 }
 
-uint8_t addVoltage (uint8_t channel, float voltage) {
+uint8_t CayenneLPP::addVoltage (uint8_t channel, float voltage) {
     if ((cursor + LPP_VOLTAGE_SIZE) > maxsize)
     {
         return 0;
@@ -226,7 +226,7 @@ uint8_t addVoltage (uint8_t channel, float voltage) {
     return cursor;
 }
 
-uint8_t addPercentage (uint8_t channel, float percent) {
+uint8_t CayenneLPP::addPercentage (uint8_t channel, float percent) {
     if ((cursor + LPP_PERCENTAGE_SIZE) > maxsize)
     {
         return 0;

--- a/CayenneLPP.cpp
+++ b/CayenneLPP.cpp
@@ -127,7 +127,7 @@ uint8_t CayenneLPP::addGenericValue (uint8_t channel, float value) {
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[0];
-#elif
+#else
     buffer[cursor++] = ptr[0];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[2];
@@ -232,7 +232,7 @@ uint8_t CayenneLPP::addVoltage (uint8_t channel, float voltage) {
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[0];
-#elif
+#else
     buffer[cursor++] = ptr[0];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[2];
@@ -258,7 +258,7 @@ uint8_t CayenneLPP::addPercentage (uint8_t channel, float percent) {
     buffer[cursor++] = ptr[2];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[0];
-#elif
+#else
     buffer[cursor++] = ptr[0];
     buffer[cursor++] = ptr[1];
     buffer[cursor++] = ptr[2];

--- a/CayenneLPP.cpp
+++ b/CayenneLPP.cpp
@@ -226,6 +226,24 @@ uint8_t addVoltage (uint8_t channel, float voltage) {
     return cursor;
 }
 
+uint8_t addPercentage (uint8_t channel, float percent) {
+    if ((cursor + LPP_PERCENTAGE_SIZE) > maxsize)
+    {
+        return 0;
+    }
+    float val = percent;
+    uint8_t *ptr = (uint8_t *)&val;
+
+    buffer[cursor++] = channel;
+    buffer[cursor++] = LPP_PERCENTAGE;
+    buffer[cursor++] = ptr[0];
+    buffer[cursor++] = ptr[1];
+    buffer[cursor++] = ptr[2];
+    buffer[cursor++] = ptr[3];
+
+    return cursor;
+}
+
 uint8_t CayenneLPP::addUnixTime(uint8_t channel, uint32_t unixtime)
 {
   if ((cursor + LPP_UNIXTIME_SIZE) > maxsize)

--- a/CayenneLPP.cpp
+++ b/CayenneLPP.cpp
@@ -208,6 +208,24 @@ uint8_t CayenneLPP::addBarometricPressure(uint8_t channel, float hpa)
   return cursor;
 }
 
+uint8_t addVoltage (uint8_t channel, float voltage) {
+    if ((cursor + LPP_VOLTAGE_SIZE) > maxsize)
+    {
+        return 0;
+    }
+    float val = voltage;
+    uint8_t *ptr = (uint8_t *)&val;
+
+    buffer[cursor++] = channel;
+    buffer[cursor++] = LPP_VOLTAGE;
+    buffer[cursor++] = ptr[0];
+    buffer[cursor++] = ptr[1];
+    buffer[cursor++] = ptr[2];
+    buffer[cursor++] = ptr[3];
+
+    return cursor;
+}
+
 uint8_t CayenneLPP::addUnixTime(uint8_t channel, uint32_t unixtime)
 {
   if ((cursor + LPP_UNIXTIME_SIZE) > maxsize)

--- a/CayenneLPP.h
+++ b/CayenneLPP.h
@@ -23,6 +23,7 @@
 #define LPP_ACCELEROMETER 113       // 2 bytes per axis, 0.001G
 #define LPP_BAROMETRIC_PRESSURE 115 // 2 bytes 0.1 hPa Unsigned
 #define LPP_VOLTAGE 116             // 4 bytes float IEEE754-2008
+#define LPP_PERCENTAGE 120          // 4 bytes float IEEE754-2008
 #define LPP_UNIXTIME 133            // 4 bytes, unsigned uint_32_t
 #define LPP_GYROMETER 134           // 2 bytes per axis, 0.01 °/s
 #define LPP_GPS 136                 // 3 byte lon/lat 0.0001 °, 3 bytes alt 0.01 meter
@@ -40,6 +41,7 @@
 #define LPP_ACCELEROMETER_SIZE 8       // 2 bytes per axis, 0.001G
 #define LPP_BAROMETRIC_PRESSURE_SIZE 4 // 2 bytes 0.1 hPa Unsigned
 #define LPP_VOLTAGE_SIZE 6             // 4 bytes float IEEE754-2008
+#define LPP_PERCENTAGE_SIZE 6          // 4 bytes float IEEE754-2008
 #define LPP_UNIXTIME_SIZE 6            // 4 bytes, unsigned uint_32_t
 #define LPP_GYROMETER_SIZE 8           // 2 bytes per axis, 0.01 °/s
 #define LPP_GPS_SIZE 11                // 3 byte lon/lat 0.0001 °, 3 bytes alt 0.01 meter
@@ -69,6 +71,7 @@ public:
   uint8_t addAccelerometer(uint8_t channel, float x, float y, float z);
   uint8_t addBarometricPressure(uint8_t channel, float hpa);
   uint8_t addVoltage(uint8_t channel, float voltage);
+  uint8_t addPercentage(uint8_t channel, float percent);
   uint8_t addUnixTime(uint8_t channel, uint32_t unixtime);
   uint8_t addGyrometer(uint8_t channel, float x, float y, float z);
   uint8_t addGPS(uint8_t channel, float latitude, float longitude, float meters);

--- a/CayenneLPP.h
+++ b/CayenneLPP.h
@@ -15,6 +15,7 @@
 #define LPP_DIGITAL_OUTPUT 1        // 1 byte
 #define LPP_ANALOG_INPUT 2          // 2 bytes, 0.01 signed
 #define LPP_ANALOG_OUTPUT 3         // 2 bytes, 0.01 signed
+#define LPP_GENERIC_SENSOR 100      // 4 bytes float IEEE754-2008
 #define LPP_LUMINOSITY 101          // 2 bytes, 1 lux unsigned
 #define LPP_PRESENCE 102            // 1 byte, 1
 #define LPP_TEMPERATURE 103         // 2 bytes, 0.1°C signed
@@ -30,6 +31,7 @@
 #define LPP_DIGITAL_OUTPUT_SIZE 3      // 1 byte
 #define LPP_ANALOG_INPUT_SIZE 4        // 2 bytes, 0.01 signed
 #define LPP_ANALOG_OUTPUT_SIZE 4       // 2 bytes, 0.01 signed
+#define LPP_GENERIC_SENSOR_SIZE 6      // 4 bytes float IEEE754-2008
 #define LPP_LUMINOSITY_SIZE 4          // 2 bytes, 1 lux unsigned
 #define LPP_PRESENCE_SIZE 3            // 1 byte, 1
 #define LPP_TEMPERATURE_SIZE 4         // 2 bytes, 0.1°C signed
@@ -58,6 +60,7 @@ public:
   uint8_t addAnalogOutput(uint8_t channel, float value);
 
   uint8_t addLuminosity(uint8_t channel, uint16_t lux);
+  uint8_t addGenericValue (uint8_t channel, float value);
   uint8_t addPresence(uint8_t channel, uint8_t value);
   uint8_t addTemperature(uint8_t channel, float celsius);
   uint8_t addRelativeHumidity(uint8_t channel, float rh);

--- a/CayenneLPP.h
+++ b/CayenneLPP.h
@@ -22,6 +22,7 @@
 #define LPP_RELATIVE_HUMIDITY 104   // 1 byte, 0.5% unsigned
 #define LPP_ACCELEROMETER 113       // 2 bytes per axis, 0.001G
 #define LPP_BAROMETRIC_PRESSURE 115 // 2 bytes 0.1 hPa Unsigned
+#define LPP_VOLTAGE 116             // 4 bytes float IEEE754-2008
 #define LPP_UNIXTIME 133            // 4 bytes, unsigned uint_32_t
 #define LPP_GYROMETER 134           // 2 bytes per axis, 0.01 °/s
 #define LPP_GPS 136                 // 3 byte lon/lat 0.0001 °, 3 bytes alt 0.01 meter
@@ -38,7 +39,8 @@
 #define LPP_RELATIVE_HUMIDITY_SIZE 3   // 1 byte, 0.5% unsigned
 #define LPP_ACCELEROMETER_SIZE 8       // 2 bytes per axis, 0.001G
 #define LPP_BAROMETRIC_PRESSURE_SIZE 4 // 2 bytes 0.1 hPa Unsigned
-#define LPP_UNIXTIME_SIZE 6 		// 4 bytes, unsigned uint_32_t
+#define LPP_VOLTAGE_SIZE 6             // 4 bytes float IEEE754-2008
+#define LPP_UNIXTIME_SIZE 6            // 4 bytes, unsigned uint_32_t
 #define LPP_GYROMETER_SIZE 8           // 2 bytes per axis, 0.01 °/s
 #define LPP_GPS_SIZE 11                // 3 byte lon/lat 0.0001 °, 3 bytes alt 0.01 meter
 
@@ -66,6 +68,7 @@ public:
   uint8_t addRelativeHumidity(uint8_t channel, float rh);
   uint8_t addAccelerometer(uint8_t channel, float x, float y, float z);
   uint8_t addBarometricPressure(uint8_t channel, float hpa);
+  uint8_t addVoltage(uint8_t channel, float voltage);
   uint8_t addUnixTime(uint8_t channel, uint32_t unixtime);
   uint8_t addGyrometer(uint8_t channel, float x, float y, float z);
   uint8_t addGPS(uint8_t channel, float latitude, float longitude, float meters);

--- a/keywords.txt
+++ b/keywords.txt
@@ -24,11 +24,14 @@ addAnalogInput	KEYWORD2
 addAnalogOutput	KEYWORD2
 
 addLuminosity	KEYWORD2
+addGenericValue	KEYWORD2
 addPresence	KEYWORD2
 addTemperature	KEYWORD2
 addRelativeHumidity	KEYWORD2
 addAccelerometer	KEYWORD2
 addBarometricPressure	KEYWORD2
+addVoltage	KEYWORD2
+addPercentage	KEYWORD2
 addUnixTime	KEYWORD2
 addGyrometer	KEYWORD2
 addGPS	KEYWORD2


### PR DESCRIPTION
I've added these three formats that are maybe useful. Please check that conversion method from float to binary buffer is ok for you. I'm using pointers to do the job. I don't know how to do float to buffer conversion using shifts.

Both formats are float, that should be transmitted with big endianness. I'm working on ESP8266 and ESP32 platforms, that use little endianness. They define `BYTE_ORDER` as `LITTLE_ENDIAN` , but I've not found any definition like that on Arduino platform, although it uses little endianness too. Then I've considered that if ARDUINO is defined endianness is little.