### PR TITLE
New Type RGB and PPM

### DIFF
--- a/API.md
+++ b/API.md
@@ -147,6 +147,9 @@ uint8_t addDistance(uint8_t channel, float value); // in meters (3 decimals)
 uint8_t addEnergy(uint8_t channel, float value); // in kWh (3 decimals)
 uint8_t addDirection(uint8_t channel, float value); // in degrees
 uint8_t addSwitch(uint8_t channel, uint32_t value); // 0 or 1
+
+uint8_t CayenneLPP::addPPM(uint8_t channel, uint32_t value); // 1 PPM unsigned - PPM means Parts per million 1PPM = 1 * 10 ^-6 = 0.000 001
+uint8_t CayenneLPP::addRGB(uint8_t channel, uint8_t r, uint8_t g, uint8_t b); // R: 255 G: 255 B: 255
 ```
 
 ### Method: `getError`

--- a/API.md
+++ b/API.md
@@ -148,7 +148,7 @@ uint8_t addEnergy(uint8_t channel, float value); // in kWh (3 decimals)
 uint8_t addDirection(uint8_t channel, float value); // in degrees
 uint8_t addSwitch(uint8_t channel, uint32_t value); // 0 or 1
 
-uint8_t CayenneLPP::addConentration(uint8_t channel, uint32_t value); // 1 PPM unsigned - PPM means Parts per million 1PPM = 1 * 10 ^-6 = 0.000 001
+uint8_t CayenneLPP::addConcentration(uint8_t channel, uint32_t value); // 1 PPM unsigned - PPM means Parts per million 1PPM = 1 * 10 ^-6 = 0.000 001
 uint8_t CayenneLPP::addColour(uint8_t channel, uint8_t r, uint8_t g, uint8_t b); // R: 255 G: 255 B: 255
 ```
 

--- a/API.md
+++ b/API.md
@@ -148,8 +148,8 @@ uint8_t addEnergy(uint8_t channel, float value); // in kWh (3 decimals)
 uint8_t addDirection(uint8_t channel, float value); // in degrees
 uint8_t addSwitch(uint8_t channel, uint32_t value); // 0 or 1
 
-uint8_t CayenneLPP::addPPM(uint8_t channel, uint32_t value); // 1 PPM unsigned - PPM means Parts per million 1PPM = 1 * 10 ^-6 = 0.000 001
-uint8_t CayenneLPP::addRGB(uint8_t channel, uint8_t r, uint8_t g, uint8_t b); // R: 255 G: 255 B: 255
+uint8_t CayenneLPP::addConentration(uint8_t channel, uint32_t value); // 1 PPM unsigned - PPM means Parts per million 1PPM = 1 * 10 ^-6 = 0.000 001
+uint8_t CayenneLPP::addColour(uint8_t channel, uint8_t r, uint8_t g, uint8_t b); // R: 255 G: 255 B: 255
 ```
 
 ### Method: `getError`

--- a/decoders/decoder.js
+++ b/decoders/decoder.js
@@ -28,7 +28,7 @@
  *  Frequency           3318    118     76      4           1 Hz Unsigned MSB
  *  Percentage          3320    120     78      1           1% Unsigned
  *  Altitude            3321    121     79      2           1m Signed MSB
- *  Conentration        3325    125     7D      2           1 PPM unsigned : 1pmm = 1 * 10 ^-6 = 0.000 001
+ *  Concentration       3325    125     7D      2           1 PPM unsigned : 1pmm = 1 * 10 ^-6 = 0.000 001
  *  Power               3328    128     80      2           1 W Unsigned MSB
  *  Distance            3330    130     82      4           0.001m Unsigned MSB
  *  Energy              3331    131     83      4           0.001kWh Unsigned MSB
@@ -60,7 +60,7 @@ function lppDecode(bytes) {
         118: {'size': 4, 'name': 'frequency', 'signed': false, 'divisor': 1},
         120: {'size': 1, 'name': 'percentage', 'signed': false, 'divisor': 1},
         121: {'size': 2, 'name': 'altitude', 'signed': true, 'divisor': 1},
-		125: {'size': 2, 'name': 'conentration', 'signed': false, 'divisor': 1},
+		125: {'size': 2, 'name': 'concentration', 'signed': false, 'divisor': 1},
         128: {'size': 2, 'name': 'power', 'signed': false, 'divisor': 1},
         130: {'size': 4, 'name': 'distance', 'signed': false, 'divisor': 1000},
         131: {'size': 4, 'name': 'energy', 'signed': false, 'divisor': 1000},

--- a/decoders/decoder.js
+++ b/decoders/decoder.js
@@ -33,6 +33,8 @@
  *  Energy              3331    131     83      4           0.001kWh Unsigned MSB
  *  Direction           3332    132     84      2           1º Unsigned MSB
  *  Switch              3342    142     8E      1           0/1
+ *  PPM                 3343    143     8F      2           1 PPM unsigned : 1pmm = 1 * 10 ^-6 = 0.000 001
+ *  RGB                 3345    144     90      3           R: 255 G: 255 B: 255
  * 
  */
 
@@ -65,6 +67,8 @@ function lppDecode(bytes) {
         134: {'size': 6, 'name': 'gyrometer', 'signed': true , 'divisor': 100},
         136: {'size': 9, 'name': 'gps', 'signed': true, 'divisor': [10000,10000,100]},
         142: {'size': 1, 'name': 'switch', 'signed': false, 'divisor': 1},
+		143: {'size': 2, 'name': 'ppm', 'signed': false, 'divisor': 1},
+		144: {'size': 3, 'name': 'rgb', 'signed': false, 'divisor': 1},
     };
 
     function arrayToDecimal(stream, is_signed, divisor) {
@@ -116,6 +120,13 @@ function lppDecode(bytes) {
                     'latitude': arrayToDecimal(bytes.slice(i+0, i+3), type.signed, type.divisor[0]),
                     'longitude': arrayToDecimal(bytes.slice(i+3, i+6), type.signed, type.divisor[1]),
                     'altitude': arrayToDecimal(bytes.slice(i+6, i+9), type.signed, type.divisor[2])
+                };
+                break;
+			case 144:   // RGB
+				s_value = {
+                    'r': arrayToDecimal(bytes.slice(i+0, i+1), type.signed, type.divisor),
+                    'g': arrayToDecimal(bytes.slice(i+1, i+2), type.signed, type.divisor),
+                    'b': arrayToDecimal(bytes.slice(i+2, i+3), type.signed, type.divisor)
                 };
                 break;
 

--- a/decoders/decoder.js
+++ b/decoders/decoder.js
@@ -28,13 +28,14 @@
  *  Frequency           3318    118     76      4           1 Hz Unsigned MSB
  *  Percentage          3320    120     78      1           1% Unsigned
  *  Altitude            3321    121     79      2           1m Signed MSB
+ *  Conentration        3325    125     7D      2           1 PPM unsigned : 1pmm = 1 * 10 ^-6 = 0.000 001
  *  Power               3328    128     80      2           1 W Unsigned MSB
  *  Distance            3330    130     82      4           0.001m Unsigned MSB
  *  Energy              3331    131     83      4           0.001kWh Unsigned MSB
+ *  Colour              3335    135     87      3           R: 255 G: 255 B: 255
  *  Direction           3332    132     84      2           1º Unsigned MSB
  *  Switch              3342    142     8E      1           0/1
- *  PPM                 3343    143     8F      2           1 PPM unsigned : 1pmm = 1 * 10 ^-6 = 0.000 001
- *  RGB                 3345    144     90      3           R: 255 G: 255 B: 255
+
  * 
  */
 
@@ -59,16 +60,16 @@ function lppDecode(bytes) {
         118: {'size': 4, 'name': 'frequency', 'signed': false, 'divisor': 1},
         120: {'size': 1, 'name': 'percentage', 'signed': false, 'divisor': 1},
         121: {'size': 2, 'name': 'altitude', 'signed': true, 'divisor': 1},
+		125: {'size': 2, 'name': 'conentration', 'signed': false, 'divisor': 1},
         128: {'size': 2, 'name': 'power', 'signed': false, 'divisor': 1},
         130: {'size': 4, 'name': 'distance', 'signed': false, 'divisor': 1000},
         131: {'size': 4, 'name': 'energy', 'signed': false, 'divisor': 1000},
         132: {'size': 2, 'name': 'direction', 'signed': false, 'divisor': 1},
         133: {'size': 4, 'name': 'time', 'signed': false, 'divisor': 1},
         134: {'size': 6, 'name': 'gyrometer', 'signed': true , 'divisor': 100},
+		135: {'size': 3, 'name': 'colour', 'signed': false, 'divisor': 1},
         136: {'size': 9, 'name': 'gps', 'signed': true, 'divisor': [10000,10000,100]},
         142: {'size': 1, 'name': 'switch', 'signed': false, 'divisor': 1},
-		143: {'size': 2, 'name': 'ppm', 'signed': false, 'divisor': 1},
-		144: {'size': 3, 'name': 'rgb', 'signed': false, 'divisor': 1},
     };
 
     function arrayToDecimal(stream, is_signed, divisor) {
@@ -122,7 +123,7 @@ function lppDecode(bytes) {
                     'altitude': arrayToDecimal(bytes.slice(i+6, i+9), type.signed, type.divisor[2])
                 };
                 break;
-			case 144:   // RGB
+			case 135:   // Colour
 				s_value = {
                     'r': arrayToDecimal(bytes.slice(i+0, i+1), type.signed, type.divisor),
                     'g': arrayToDecimal(bytes.slice(i+1, i+2), type.signed, type.divisor),

--- a/examples/Decode/Decode.ino
+++ b/examples/Decode/Decode.ino
@@ -46,6 +46,10 @@ void setup()
   lpp.addEnergy(1 , 19.055);
   lpp.addDirection(1 , 90);
   lpp.addSwitch(1 , 0);
+  
+  lpp.addPPM(1 , 512);
+  lpp.addRGB(1 , 64, 128, 255);
+
 
   lpp.decode(lpp.getBuffer(), lpp.getSize(), root);
   

--- a/examples/Decode/Decode.ino
+++ b/examples/Decode/Decode.ino
@@ -47,7 +47,7 @@ void setup()
   lpp.addDirection(1 , 90);
   lpp.addSwitch(1 , 0);
   
-  lpp.addConentration(1 , 512);
+  lpp.addConcentration(1 , 512);
   lpp.addColour(1 , 64, 128, 255);
 
 

--- a/examples/Decode/Decode.ino
+++ b/examples/Decode/Decode.ino
@@ -47,8 +47,8 @@ void setup()
   lpp.addDirection(1 , 90);
   lpp.addSwitch(1 , 0);
   
-  lpp.addPPM(1 , 512);
-  lpp.addRGB(1 , 64, 128, 255);
+  lpp.addConentration(1 , 512);
+  lpp.addColour(1 , 64, 128, 255);
 
 
   lpp.decode(lpp.getBuffer(), lpp.getSize(), root);

--- a/examples/DecodeTTN/DecodeTTN.ino
+++ b/examples/DecodeTTN/DecodeTTN.ino
@@ -46,6 +46,10 @@ void setup()
   lpp.addEnergy(1 , 19.055);
   lpp.addDirection(1 , 90);
   lpp.addSwitch(1 , 0);
+  
+  lpp.addPPM(1 , 512);
+  lpp.addRGB(1 , 64, 128, 255);
+
 
   lpp.decodeTTN(lpp.getBuffer(), lpp.getSize(), root);
   

--- a/examples/DecodeTTN/DecodeTTN.ino
+++ b/examples/DecodeTTN/DecodeTTN.ino
@@ -47,7 +47,7 @@ void setup()
   lpp.addDirection(1 , 90);
   lpp.addSwitch(1 , 0);
   
-  lpp.addConentration(1 , 512);
+  lpp.addConcentration(1 , 512);
   lpp.addColour(1 , 64, 128, 255);
 
 

--- a/examples/DecodeTTN/DecodeTTN.ino
+++ b/examples/DecodeTTN/DecodeTTN.ino
@@ -47,8 +47,8 @@ void setup()
   lpp.addDirection(1 , 90);
   lpp.addSwitch(1 , 0);
   
-  lpp.addPPM(1 , 512);
-  lpp.addRGB(1 , 64, 128, 255);
+  lpp.addConentration(1 , 512);
+  lpp.addColour(1 , 64, 128, 255);
 
 
   lpp.decodeTTN(lpp.getBuffer(), lpp.getSize(), root);

--- a/keywords.txt
+++ b/keywords.txt
@@ -44,8 +44,8 @@ addEnergy	KEYWORD2
 addDirection	KEYWORD2
 addSwitch	KEYWORD2
 
-addPPM	KEYWORD2
-addRGB	KEYWORD2
+addConentration 	KEYWORD2
+addColour	KEYWORD2
 
 getTypeName	KEYWORD2
 decode	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -44,7 +44,7 @@ addEnergy	KEYWORD2
 addDirection	KEYWORD2
 addSwitch	KEYWORD2
 
-addConentration 	KEYWORD2
+addConcentration 	KEYWORD2
 addColour	KEYWORD2
 
 getTypeName	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -44,6 +44,9 @@ addEnergy	KEYWORD2
 addDirection	KEYWORD2
 addSwitch	KEYWORD2
 
+addPPM	KEYWORD2
+addRGB	KEYWORD2
+
 getTypeName	KEYWORD2
 decode	KEYWORD2
 decodeTTN	KEYWORD2

--- a/src/CayenneLPP.cpp
+++ b/src/CayenneLPP.cpp
@@ -66,6 +66,8 @@ bool CayenneLPP::isType(uint8_t type) {
   if (LPP_GYROMETER == type) return true;
   if (LPP_GPS == type) return true;
   if (LPP_SWITCH == type) return true;
+  if (LPP_PPM == type) return true;
+  if (LPP_RGB == type) return true;
   return false;
 }
 
@@ -94,6 +96,8 @@ const char * CayenneLPP::getTypeName(uint8_t type) {
   if (LPP_GYROMETER == type) return "gyrometer";
   if (LPP_GPS == type) return "gps";
   if (LPP_SWITCH == type) return "switch";
+  if (LPP_PPM == type) return "ppm";
+  if (LPP_RGB == type) return "rgb";
   return 0;
 }
 
@@ -122,6 +126,8 @@ uint8_t CayenneLPP::getTypeSize(uint8_t type) {
   if (LPP_GYROMETER == type) return LPP_GYROMETER_SIZE;
   if (LPP_GPS == type) return LPP_GPS_SIZE;
   if (LPP_SWITCH == type) return LPP_SWITCH_SIZE;
+  if (LPP_PPM == type) return LPP_PPM_SIZE;
+  if (LPP_RGB == type) return LPP_RGB_SIZE;
   return 0;
 }
 
@@ -149,6 +155,8 @@ uint32_t CayenneLPP::getTypeMultiplier(uint8_t type) {
   if (LPP_UNIXTIME == type) return LPP_UNIXTIME_MULT;
   if (LPP_GYROMETER == type) return LPP_GYROMETER_MULT;
   if (LPP_SWITCH == type) return LPP_SWITCH_MULT;
+  if (LPP_PPM == type) return LPP_PPM_MULT;
+  if (LPP_RGB == type) return LPP_RGB_MULT;
   return 0;
 }
 
@@ -296,6 +304,27 @@ uint8_t CayenneLPP::addDirection(uint8_t channel, float value) {
 
 uint8_t CayenneLPP::addSwitch(uint8_t channel, uint32_t value) {
   return addField(LPP_SWITCH, channel, value);
+}
+
+uint8_t CayenneLPP::addPPM(uint8_t channel, uint32_t value) {
+  return addField(LPP_PPM, channel, value);
+}
+
+uint8_t CayenneLPP::addRGB(uint8_t channel, uint8_t r, uint8_t g, uint8_t b)
+{
+  // check buffer overflow
+  if ((_cursor + LPP_RGB_SIZE + 2) > _maxsize) {
+    _error = LPP_ERROR_OVERFLOW;
+    return 0;
+  }
+  _buffer[_cursor++] = channel;
+  _buffer[_cursor++] = LPP_RGB;
+  _buffer[_cursor++] = r;
+  _buffer[_cursor++] = g;
+  _buffer[_cursor++] = b;
+ 
+
+  return _cursor;
 }
 
 uint8_t CayenneLPP::addAccelerometer(uint8_t channel, float x, float y, float z) {
@@ -446,7 +475,14 @@ uint8_t CayenneLPP::decode(uint8_t *buffer, uint8_t len, JsonArray& root) {
     data["name"] = String(getTypeName(type));
 
     // Parse types
-    if (LPP_ACCELEROMETER == type || LPP_GYROMETER == type) {
+	if (LPP_RGB == type) {
+
+      JsonObject object = data.createNestedObject("value");
+      object["r"] = getValue(&buffer[index], 1, multiplier, is_signed);
+      object["g"] = getValue(&buffer[index+1], 1, multiplier, is_signed);
+      object["b"] = getValue(&buffer[index+2], 1, multiplier, is_signed);
+
+    } else if (LPP_ACCELEROMETER == type || LPP_GYROMETER == type) {
 
       JsonObject object = data.createNestedObject("value");
       object["x"] = getValue(&buffer[index], 2, multiplier, is_signed);
@@ -512,7 +548,13 @@ uint8_t CayenneLPP::decodeTTN(uint8_t *buffer, uint8_t len, JsonObject& root) {
     String name = String(getTypeName(type)) + "_" + channel;
 
     // Parse types
-    if (LPP_ACCELEROMETER == type || LPP_GYROMETER == type) {
+	if (LPP_RGB == type) {
+      JsonObject object = root.createNestedObject(name);
+      object["r"] = getValue(&buffer[index], 1, multiplier, is_signed);
+      object["g"] = getValue(&buffer[index+1], 1, multiplier, is_signed);
+      object["b"] = getValue(&buffer[index+2], 1, multiplier, is_signed);
+
+    } else if (LPP_ACCELEROMETER == type || LPP_GYROMETER == type) {
 
       JsonObject object = root.createNestedObject(name);
       object["x"] = getValue(&buffer[index], 2, multiplier, is_signed);

--- a/src/CayenneLPP.cpp
+++ b/src/CayenneLPP.cpp
@@ -66,7 +66,7 @@ bool CayenneLPP::isType(uint8_t type) {
   if (LPP_GYROMETER == type) return true;
   if (LPP_GPS == type) return true;
   if (LPP_SWITCH == type) return true;
-  if (LPP_CONENTRATION == type) return true;
+  if (LPP_CONCENTRATION == type) return true;
   if (LPP_COLOUR == type) return true;
   return false;
 }
@@ -96,7 +96,7 @@ const char * CayenneLPP::getTypeName(uint8_t type) {
   if (LPP_GYROMETER == type) return "gyrometer";
   if (LPP_GPS == type) return "gps";
   if (LPP_SWITCH == type) return "switch";
-  if (LPP_CONENTRATION == type) return "conentration";
+  if (LPP_CONCENTRATION == type) return "concentration";
   if (LPP_COLOUR == type) return "colour";
   return 0;
 }
@@ -126,7 +126,7 @@ uint8_t CayenneLPP::getTypeSize(uint8_t type) {
   if (LPP_GYROMETER == type) return LPP_GYROMETER_SIZE;
   if (LPP_GPS == type) return LPP_GPS_SIZE;
   if (LPP_SWITCH == type) return LPP_SWITCH_SIZE;
-  if (LPP_CONENTRATION == type) return LPP_CONENTRATION_SIZE;
+  if (LPP_CONCENTRATION == type) return LPP_CONCENTRATION_SIZE;
   if (LPP_COLOUR == type) return LPP_COLOUR_SIZE;
   return 0;
 }
@@ -155,7 +155,7 @@ uint32_t CayenneLPP::getTypeMultiplier(uint8_t type) {
   if (LPP_UNIXTIME == type) return LPP_UNIXTIME_MULT;
   if (LPP_GYROMETER == type) return LPP_GYROMETER_MULT;
   if (LPP_SWITCH == type) return LPP_SWITCH_MULT;
-  if (LPP_CONENTRATION == type) return LPP_CONENTRATION_MULT;
+  if (LPP_CONCENTRATION == type) return LPP_CONCENTRATION_MULT;
   if (LPP_COLOUR == type) return LPP_COLOUR_MULT;
   return 0;
 }
@@ -306,8 +306,8 @@ uint8_t CayenneLPP::addSwitch(uint8_t channel, uint32_t value) {
   return addField(LPP_SWITCH, channel, value);
 }
 
-uint8_t CayenneLPP::addConentration(uint8_t channel, uint32_t value) {
-  return addField(LPP_CONENTRATION, channel, value);
+uint8_t CayenneLPP::addConcentration(uint8_t channel, uint32_t value) {
+  return addField(LPP_CONCENTRATION, channel, value);
 }
 
 uint8_t CayenneLPP::addColour(uint8_t channel, uint8_t r, uint8_t g, uint8_t b)

--- a/src/CayenneLPP.cpp
+++ b/src/CayenneLPP.cpp
@@ -66,8 +66,8 @@ bool CayenneLPP::isType(uint8_t type) {
   if (LPP_GYROMETER == type) return true;
   if (LPP_GPS == type) return true;
   if (LPP_SWITCH == type) return true;
-  if (LPP_PPM == type) return true;
-  if (LPP_RGB == type) return true;
+  if (LPP_CONENTRATION == type) return true;
+  if (LPP_COLOUR == type) return true;
   return false;
 }
 
@@ -96,8 +96,8 @@ const char * CayenneLPP::getTypeName(uint8_t type) {
   if (LPP_GYROMETER == type) return "gyrometer";
   if (LPP_GPS == type) return "gps";
   if (LPP_SWITCH == type) return "switch";
-  if (LPP_PPM == type) return "ppm";
-  if (LPP_RGB == type) return "rgb";
+  if (LPP_CONENTRATION == type) return "conentration";
+  if (LPP_COLOUR == type) return "colour";
   return 0;
 }
 
@@ -126,8 +126,8 @@ uint8_t CayenneLPP::getTypeSize(uint8_t type) {
   if (LPP_GYROMETER == type) return LPP_GYROMETER_SIZE;
   if (LPP_GPS == type) return LPP_GPS_SIZE;
   if (LPP_SWITCH == type) return LPP_SWITCH_SIZE;
-  if (LPP_PPM == type) return LPP_PPM_SIZE;
-  if (LPP_RGB == type) return LPP_RGB_SIZE;
+  if (LPP_CONENTRATION == type) return LPP_CONENTRATION_SIZE;
+  if (LPP_COLOUR == type) return LPP_COLOUR_SIZE;
   return 0;
 }
 
@@ -155,8 +155,8 @@ uint32_t CayenneLPP::getTypeMultiplier(uint8_t type) {
   if (LPP_UNIXTIME == type) return LPP_UNIXTIME_MULT;
   if (LPP_GYROMETER == type) return LPP_GYROMETER_MULT;
   if (LPP_SWITCH == type) return LPP_SWITCH_MULT;
-  if (LPP_PPM == type) return LPP_PPM_MULT;
-  if (LPP_RGB == type) return LPP_RGB_MULT;
+  if (LPP_CONENTRATION == type) return LPP_CONENTRATION_MULT;
+  if (LPP_COLOUR == type) return LPP_COLOUR_MULT;
   return 0;
 }
 
@@ -306,19 +306,19 @@ uint8_t CayenneLPP::addSwitch(uint8_t channel, uint32_t value) {
   return addField(LPP_SWITCH, channel, value);
 }
 
-uint8_t CayenneLPP::addPPM(uint8_t channel, uint32_t value) {
-  return addField(LPP_PPM, channel, value);
+uint8_t CayenneLPP::addConentration(uint8_t channel, uint32_t value) {
+  return addField(LPP_CONENTRATION, channel, value);
 }
 
-uint8_t CayenneLPP::addRGB(uint8_t channel, uint8_t r, uint8_t g, uint8_t b)
+uint8_t CayenneLPP::addColour(uint8_t channel, uint8_t r, uint8_t g, uint8_t b)
 {
   // check buffer overflow
-  if ((_cursor + LPP_RGB_SIZE + 2) > _maxsize) {
+  if ((_cursor + LPP_COLOUR_SIZE + 2) > _maxsize) {
     _error = LPP_ERROR_OVERFLOW;
     return 0;
   }
   _buffer[_cursor++] = channel;
-  _buffer[_cursor++] = LPP_RGB;
+  _buffer[_cursor++] = LPP_COLOUR;
   _buffer[_cursor++] = r;
   _buffer[_cursor++] = g;
   _buffer[_cursor++] = b;
@@ -475,7 +475,7 @@ uint8_t CayenneLPP::decode(uint8_t *buffer, uint8_t len, JsonArray& root) {
     data["name"] = String(getTypeName(type));
 
     // Parse types
-	if (LPP_RGB == type) {
+	if (LPP_COLOUR == type) {
 
       JsonObject object = data.createNestedObject("value");
       object["r"] = getValue(&buffer[index], 1, multiplier, is_signed);
@@ -548,7 +548,7 @@ uint8_t CayenneLPP::decodeTTN(uint8_t *buffer, uint8_t len, JsonObject& root) {
     String name = String(getTypeName(type)) + "_" + channel;
 
     // Parse types
-	if (LPP_RGB == type) {
+	if (LPP_COLOUR == type) {
       JsonObject object = root.createNestedObject(name);
       object["r"] = getValue(&buffer[index], 1, multiplier, is_signed);
       object["g"] = getValue(&buffer[index+1], 1, multiplier, is_signed);

--- a/src/CayenneLPP.h
+++ b/src/CayenneLPP.h
@@ -33,6 +33,8 @@
 #define LPP_GYROMETER                   134   // 2 bytes per axis, 0.01 °/s
 #define LPP_GPS                         136   // 3 byte lon/lat 0.0001 °, 3 bytes alt 0.01 meter
 #define LPP_SWITCH                      142   // 1 byte, 0/1
+#define LPP_PPM                         143   // 2 bytes, 1 ppm unsigned
+#define LPP_RGB                         144   // 1 byte per RGB Color
 
 // Only Data Size
 #define LPP_DIGITAL_INPUT_SIZE          1
@@ -59,6 +61,8 @@
 #define LPP_GYROMETER_SIZE              6
 #define LPP_GPS_SIZE                    9
 #define LPP_SWITCH_SIZE                 1
+#define LPP_PPM_SIZE                    2
+#define LPP_RGB_SIZE                    3
 
 // Multipliers
 #define LPP_DIGITAL_INPUT_MULT          1
@@ -86,6 +90,8 @@
 #define LPP_GPS_LAT_LON_MULT            10000
 #define LPP_GPS_ALT_MULT                100
 #define LPP_SWITCH_MULT                 1
+#define LPP_PPM_MULT                    1
+#define LPP_RGB_MULT                    1
 
 #define LPP_ERROR_OK                    0
 #define LPP_ERROR_OVERFLOW              1
@@ -136,6 +142,8 @@ public:
   uint8_t addEnergy(uint8_t channel, float value);
   uint8_t addDirection(uint8_t channel, float value);
   uint8_t addSwitch(uint8_t channel, uint32_t value);
+  uint8_t addPPM(uint8_t channel, uint32_t value);
+  uint8_t addRGB(uint8_t channel, uint8_t r, uint8_t g, uint8_t b);
 
 protected:
 

--- a/src/CayenneLPP.h
+++ b/src/CayenneLPP.h
@@ -25,7 +25,7 @@
 #define LPP_FREQUENCY                   118   // 4 bytes 1Hz unsigned
 #define LPP_PERCENTAGE                  120   // 1 byte 1-100% unsigned
 #define LPP_ALTITUDE                    121   // 2 byte 1m signed
-#define LPP_CONENTRATION                125   // 2 bytes, 1 ppm unsigned
+#define LPP_CONCENTRATION               125   // 2 bytes, 1 ppm unsigned
 #define LPP_POWER                       128   // 2 byte, 1W, unsigned
 #define LPP_DISTANCE                    130   // 4 byte, 0.001m, unsigned
 #define LPP_ENERGY                      131   // 4 byte, 0.001kWh, unsigned
@@ -61,7 +61,7 @@
 #define LPP_GYROMETER_SIZE              6
 #define LPP_GPS_SIZE                    9
 #define LPP_SWITCH_SIZE                 1
-#define LPP_CONENTRATION_SIZE           2
+#define LPP_CONCENTRATION_SIZE          2
 #define LPP_COLOUR_SIZE                 3
 
 // Multipliers
@@ -90,7 +90,7 @@
 #define LPP_GPS_LAT_LON_MULT            10000
 #define LPP_GPS_ALT_MULT                100
 #define LPP_SWITCH_MULT                 1
-#define LPP_CONENTRATION_MULT           1
+#define LPP_CONCENTRATION_MULT          1
 #define LPP_COLOUR_MULT                 1
 
 #define LPP_ERROR_OK                    0
@@ -142,7 +142,7 @@ public:
   uint8_t addEnergy(uint8_t channel, float value);
   uint8_t addDirection(uint8_t channel, float value);
   uint8_t addSwitch(uint8_t channel, uint32_t value);
-  uint8_t addConentration(uint8_t channel, uint32_t value);
+  uint8_t addConcentration(uint8_t channel, uint32_t value);
   uint8_t addColour(uint8_t channel, uint8_t r, uint8_t g, uint8_t b);
 
 protected:

--- a/src/CayenneLPP.h
+++ b/src/CayenneLPP.h
@@ -25,16 +25,16 @@
 #define LPP_FREQUENCY                   118   // 4 bytes 1Hz unsigned
 #define LPP_PERCENTAGE                  120   // 1 byte 1-100% unsigned
 #define LPP_ALTITUDE                    121   // 2 byte 1m signed
+#define LPP_CONENTRATION                125   // 2 bytes, 1 ppm unsigned
 #define LPP_POWER                       128   // 2 byte, 1W, unsigned
 #define LPP_DISTANCE                    130   // 4 byte, 0.001m, unsigned
 #define LPP_ENERGY                      131   // 4 byte, 0.001kWh, unsigned
 #define LPP_DIRECTION                   132   // 2 bytes, 1deg, unsigned
 #define LPP_UNIXTIME                    133   // 4 bytes, unsigned
 #define LPP_GYROMETER                   134   // 2 bytes per axis, 0.01 °/s
+#define LPP_COLOUR                      135   // 1 byte per RGB Color
 #define LPP_GPS                         136   // 3 byte lon/lat 0.0001 °, 3 bytes alt 0.01 meter
 #define LPP_SWITCH                      142   // 1 byte, 0/1
-#define LPP_PPM                         143   // 2 bytes, 1 ppm unsigned
-#define LPP_RGB                         144   // 1 byte per RGB Color
 
 // Only Data Size
 #define LPP_DIGITAL_INPUT_SIZE          1
@@ -61,8 +61,8 @@
 #define LPP_GYROMETER_SIZE              6
 #define LPP_GPS_SIZE                    9
 #define LPP_SWITCH_SIZE                 1
-#define LPP_PPM_SIZE                    2
-#define LPP_RGB_SIZE                    3
+#define LPP_CONENTRATION_SIZE           2
+#define LPP_COLOUR_SIZE                 3
 
 // Multipliers
 #define LPP_DIGITAL_INPUT_MULT          1
@@ -90,8 +90,8 @@
 #define LPP_GPS_LAT_LON_MULT            10000
 #define LPP_GPS_ALT_MULT                100
 #define LPP_SWITCH_MULT                 1
-#define LPP_PPM_MULT                    1
-#define LPP_RGB_MULT                    1
+#define LPP_CONENTRATION_MULT           1
+#define LPP_COLOUR_MULT                 1
 
 #define LPP_ERROR_OK                    0
 #define LPP_ERROR_OVERFLOW              1
@@ -142,8 +142,8 @@ public:
   uint8_t addEnergy(uint8_t channel, float value);
   uint8_t addDirection(uint8_t channel, float value);
   uint8_t addSwitch(uint8_t channel, uint32_t value);
-  uint8_t addPPM(uint8_t channel, uint32_t value);
-  uint8_t addRGB(uint8_t channel, uint8_t r, uint8_t g, uint8_t b);
+  uint8_t addConentration(uint8_t channel, uint32_t value);
+  uint8_t addColour(uint8_t channel, uint8_t r, uint8_t g, uint8_t b);
 
 protected:
 

--- a/test/aunit/main.cpp
+++ b/test/aunit/main.cpp
@@ -193,7 +193,19 @@ testF(EncoderTest, Frequency) {
 
 testF(EncoderTest, Altitude) {
     lpp->addAltitude(5, -17);
-    uint8_t expected[] = {0x05,0x79,0xFF,0XEF};
+    uint8_t expected[] = {0x05,0x79,0xFF,0xEF};
+    compare(sizeof(expected), expected);
+}
+
+testF(EncoderTest, PPM) {
+    lpp->addPPM(4, 4079);
+    uint8_t expected[] = {0x05,0x8F,0x0F,0xEF};
+    compare(sizeof(expected), expected);
+}
+
+testF(EncoderTest, RGB) {
+    lpp->addPPM(7, 24, 239, 15);
+    uint8_t expected[] = {0x07,0x90,0x0F,0xEF, 0x18};
     compare(sizeof(expected), expected);
 }
 

--- a/test/aunit/main.cpp
+++ b/test/aunit/main.cpp
@@ -197,15 +197,15 @@ testF(EncoderTest, Altitude) {
     compare(sizeof(expected), expected);
 }
 
-testF(EncoderTest, PPM) {
-    lpp->addPPM(4, 4079);
-    uint8_t expected[] = {0x05,0x8F,0x0F,0xEF};
+testF(EncoderTest, Conentration) {
+    lpp->addConentration(4, 4079);
+    uint8_t expected[] = {0x05,0x7D,0x0F,0xEF};
     compare(sizeof(expected), expected);
 }
 
-testF(EncoderTest, RGB) {
-    lpp->addPPM(7, 24, 239, 15);
-    uint8_t expected[] = {0x07,0x90,0x0F,0xEF, 0x18};
+testF(EncoderTest, Colour) {
+    lpp->addColour(7, 24, 239, 15);
+    uint8_t expected[] = {0x07,0x87,0x0F,0xEF, 0x18};
     compare(sizeof(expected), expected);
 }
 

--- a/test/aunit/main.cpp
+++ b/test/aunit/main.cpp
@@ -197,8 +197,8 @@ testF(EncoderTest, Altitude) {
     compare(sizeof(expected), expected);
 }
 
-testF(EncoderTest, Conentration) {
-    lpp->addConentration(4, 4079);
+testF(EncoderTest, Concentration) {
+    lpp->addConcentration(4, 4079);
     uint8_t expected[] = {0x05,0x7D,0x0F,0xEF};
     compare(sizeof(expected), expected);
 }


### PR DESCRIPTION
Hi ElectronicCats Team

Thank you for your awesome CayenneLPP library. For a project we needed some additional value Types, and maybe you'll be interested in this changes.
New Values Type that we added: 

uint8_t CayenneLPP::addPPM(uint8_t channel, uint32_t value); // 1 PPM unsigned - PPM means Parts per million 1PPM = 1 * 10 ^-6 = 0.000 001
uint8_t CayenneLPP::addRGB(uint8_t channel, uint8_t r, uint8_t g, uint8_t b); // R: 255 G: 255 B: 255

addPPM(0, 401);  = 00 8F 01 91
{
  "ppm_0": 401
}
and
addRGB(0, 1, 145, 255); = 00 90 01 91 FF
{
  "rgb_0": {
    "b": 255,
    "g": 145,
    "r": 1
  }
}