### PR TITLE
Changing 'power' data type from uint32_t to float, since it is decimal number

### DIFF
--- a/API.md
+++ b/API.md
@@ -142,7 +142,7 @@ uint8_t addCurrent(uint8_t channel, float value); // in amperes (3 decimals)
 uint8_t addFrequency(uint8_t channel, uint32_t value); // in hertzs
 uint8_t addPercentage(uint8_t channel, uint32_t value); // 0 to 100
 uint8_t addAltitude(uint8_t channel, float value); // in meters
-uint8_t addPower(uint8_t channel, uint32_t value); // in watts
+uint8_t addPower(uint8_t channel, float value); // in watts
 uint8_t addDistance(uint8_t channel, float value); // in meters (3 decimals)
 uint8_t addEnergy(uint8_t channel, float value); // in kWh (3 decimals)
 uint8_t addDirection(uint8_t channel, float value); // in degrees

--- a/src/CayenneLPP.cpp
+++ b/src/CayenneLPP.cpp
@@ -719,7 +719,7 @@ uint8_t CayenneLPP::addAltitude(uint8_t channel, float value) {
 #endif
 
 #ifndef CAYENNE_DISABLE_POWER
-uint8_t CayenneLPP::addPower(uint8_t channel, uint32_t value) {
+uint8_t CayenneLPP::addPower(uint8_t channel, float value) {
   return addField(LPP_POWER, channel, value);
 }
 #endif

--- a/src/CayenneLPP.h
+++ b/src/CayenneLPP.h
@@ -200,7 +200,7 @@ public:
   uint8_t addAltitude(uint8_t channel, float value);
 #endif
 #ifndef CAYENNE_DISABLE_POWER
-  uint8_t addPower(uint8_t channel, uint32_t value);
+  uint8_t addPower(uint8_t channel, float value);
 #endif
 #ifndef CAYENNE_DISABLE_DISTANCE
   uint8_t addDistance(uint8_t channel, float value);

--- a/src/CayenneLPPMessage.h
+++ b/src/CayenneLPPMessage.h
@@ -38,7 +38,7 @@ struct CayenneLPPMessage {
   uint32_t frequency = 0;
   uint32_t percentage = 0;
   float altitude = 0.0f;
-  uint32_t power = 0;
+  float power = 0.0f;
   float distance = 0.0f;
   float energy = 0.0f;
   float direction = 0.0f;


### PR DESCRIPTION
The 'power' field is used to store electric power in watts, therefor it is a decimal number, same as 'voltage' or 'current'

Discussion is in Issue #58 